### PR TITLE
Document api keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,3 +109,6 @@ detail.
 - [Gentoo Build Publisher: dump &
   restore](https://lunarcowboy.com/gentoo-build-publisher-dump-restore.html):
   February 2025
+- [Gentoo Build Publisher: Auth & API
+  Keys](https://lunarcowboy.com/gentoo-build-publisher-auth-api-keys.html):
+  April 2025

--- a/src/gentoo_build_publisher/contrib/deployment/gentoo-build-publisher.conf
+++ b/src/gentoo_build_publisher/contrib/deployment/gentoo-build-publisher.conf
@@ -1,6 +1,51 @@
+# This file is used by the Gentoo Build Publisher systemd units to set
+# environment variables that are used to start the GBP services.  GBP-specific
+# settings start with BUILD_PUBLISHER_. For more information, refer to the GBP
+# Install Guide.
+
+# DJANGO_SETTINGS_MODULE: This tells the Django framework where to find it's
+# own settings given the Python path. Django is used by Gentoo Build Publisher
+# for serving the web UI, GraphQL interface and some database storage. For
+# example, "djangoproject.settings" might point to
+# /home/gbp/djangoproject/settings.py To learn more about Django, see
+# https://www.djangoproject.com
 DJANGO_SETTINGS_MODULE=djangoproject.settings
-BUILD_PUBLISHER_JENKINS_API_KEY=**********************************
-BUILD_PUBLISHER_JENKINS_BASE_URL=http://localhost:8080/job/Gentoo
+
+# BUILD_PUBLISHER_JENKINS_USER: When Gentoo Build Publisher interacts with
+# Jenkins, it needs to authenticate with the Jenkins server. Authentication
+# involves sending a username and API key with the HTTP requests it sends to
+# Jenkins.  For more information, refer to the Gentoo Build Publisher Install
+# Guide and https://www.jenkins.io/doc/book/using/remote-access-api/
 BUILD_PUBLISHER_JENKINS_USER=root
+
+# BUILD_PUBLISHER_JENKINS_API_KEY: This is the API key used to authenticate
+# with Jenkins.  This key needs to be created for the given user,
+# BUILD_PUBLISHER_JENKINS_USER. Gentoo Build Publisher will utilize the user
+# and API key when giving commands to the Jenkins server, for example, pull
+# build artifacts and scheduling builds.
+BUILD_PUBLISHER_JENKINS_API_KEY=**********************************
+
+# BUILD_PUBLISHER_JENKINS_BASE_URL: This is the URL to the "root" of your GBP
+# Projects on Jenkins. Under this Jenkins "folder" will be the home of all the
+# machine builds and the "repos" folder.
+BUILD_PUBLISHER_JENKINS_BASE_URL=http://localhost:8080/job/Gentoo
+
+# BUILD_PUBLISHER_STORAGE_PATH: This is the "root" of Gentoo Build Publisher's
+# storage. All the machine's builds (binpkgs, repos, etc) are stored here.
+# This is also the location GBP uses for much of it's temporary storage.
 BUILD_PUBLISHER_STORAGE_PATH=/home/gbp/builds
+
+# BUILD_PUBLISHER_API_KEY_ENABLE: Turning this on (values of "yes", "true",
+# etc) enables authentication & authorization for (most of) Gentoo Build
+# Publisher's GraphQL mutations. GraphQL mutations are typically how commands
+# are given to GBP. By "commands" we mean such things as pulling, publishing,
+# & tagging builds.  The GBP CLI is basically a GraphQL client in that most of
+# its commands issue GraphQL mutations on the GBP server.  In addition, when
+# the Jenkins jobs issue a request to GBP to pull a build, that is also a
+# GraphQL mutation. When this is turned on all GraphQL clients will have to
+# need to authenticate (send username and API key) to the server to issue
+# certain commands. API keys can be managed with the `gbp apikey` command. For
+# a detailed breakdown on what to do when enabling authentication, consider
+# the following guide:
+# https://lunarcowboy.com/gentoo-build-publisher-auth-api-keys.html
 BUILD_PUBLISHER_API_KEY_ENABLE=no


### PR DESCRIPTION
Per #7 write an article about GBP API Keys & Authentication and add a link in the README. Additionally document the values in `contrib/deployment/gentoo-build-publisher.conf`.